### PR TITLE
Refactor Streamlit UI into reusable frontend module

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,3 +16,7 @@ Place your GOOGLE_API_KEY=AIzaXXXXXXXXXXXXXX
 streamlit run app.py
 
 ```
+
+### Frontend
+
+The Streamlit user interface is organized in `src/frontend`. Custom styles live in `src/frontend/styles.css` and are loaded by `src/frontend/ui.py`.

--- a/app.py
+++ b/app.py
@@ -22,6 +22,13 @@ from src.Prompts.agno_prompts import (
 from src.Prompts.browser_prompts import (
     generate_browser_task
 )
+
+from src.frontend.ui import (
+    set_page_config,
+    load_css,
+    render_header,
+    render_footer,
+)
 # # Load environment variables
 load_dotenv()
 
@@ -59,241 +66,10 @@ framework_descriptions = {
 
 def main():
 
-    st.set_page_config(page_title="AI BROWSER AUTOMATION", layout="wide")
+    set_page_config()
+    load_css()
+    render_header()
 
-    # Apply custom CSS
-    st.markdown("""
-    <style>
-    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
-
-    /* General App Styling */
-    .stApp {
-        font-family: 'Poppins', sans-serif;
-        background-color: #87CEEB; /* Sky blue background */
-        color: #333333;
-        padding: 2rem;
-    }
-
-    /* Navigation Bar Styling */
-    .header {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding: 1rem 2rem;
-        background-color: #4682B4; /* Steel blue for header */
-        border-radius: 10px;
-        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-        margin-bottom: 2rem;
-    }
-
-    .header-item {
-        color: #FFFFFF;
-        font-size: 1.1rem;
-        font-weight: 600;
-        text-decoration: none;
-        padding: 0.5rem 1rem;
-        border-radius: 6px;
-        text-align: center;
-        transition: background 0.3s ease, transform 0.3s ease;
-    }
-
-    .header-item:hover {
-        background: rgba(255, 255, 255, 0.2);
-        transform: translateY(-3px);
-    }
-
-    /* Button Styling */
-    .stButton > button {
-        background-color: #4682B4; /* Steel blue for buttons */
-        color: #FFFFFF;
-        font-size: 1rem;
-        font-weight: 600;
-        padding: 0.6rem 1.2rem;
-        border-radius: 8px;
-        border: none;
-        transition: background 0.3s ease, transform 0.3s ease;
-    }
-
-    .stButton > button:hover {
-        background-color: #5F9EA0; /* Cadet blue on hover */
-        transform: scale(1.05);
-    }
-
-    /* Input Fields Styling */
-    .stTextInput > div > div > input,
-    .stTextArea > div > div > textarea {
-        background-color: #F0F8FF; /* Alice blue for input fields */
-        border: 1px solid #4682B4;
-        color: #333333;
-        border-radius: 8px;
-        padding: 0.6rem;
-        transition: border 0.3s ease, box-shadow 0.3s ease;
-    }
-
-    .stTextInput > div > div > input:focus,
-    .stTextArea > div > div > textarea:focus {
-        border-color: #4682B4;
-        box-shadow: 0 0 8px rgba(70, 130, 180, 0.6);
-    }
-
-    /* Form Controls Styling */
-    .stRadio > div {
-        background-color: #F0F8FF;
-        padding: 1rem;
-        border-radius: 8px;
-        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    }
-
-    .stRadio > div:hover {
-        background-color: #E6F3FF;
-    }
-
-    /* Grid Layout Styling */
-    .stContainer {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-        gap: 2rem;
-    }
-
-    /* Footer Styling */
-    .footer {
-        text-align: center;
-        padding: 1rem;
-        background-color: #4682B4;
-        border-radius: 10px;
-        margin-top: 3rem;
-        box-shadow: 0 -4px 15px rgba(0, 0, 0, 0.2);
-        color: white;
-    }
-
-    .main-title {
-        text-align: center;
-        font-family: 'Poppins', sans-serif;
-        font-size: 45px;
-        font-weight: 600;
-        color: #333333;
-        padding: 10px 0;
-        margin-bottom: 20px;
-        border-bottom: 2px solid #4682B4;
-        width: 100%;
-        box-sizing: border-box;
-    }
-
-    .subtitle {
-        font-family: 'Poppins', sans-serif;
-        font-size: 24px;
-        color: #333333;
-        text-align: center;
-        margin-bottom: 30px;
-        font-weight: 400;
-    }
-
-    .card {
-        background-color: #F0F8FF;
-        border-radius: 16px;
-        padding: 20px;
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-        border: 1px solid rgba(70, 130, 180, 0.3);
-        margin-bottom: 20px;
-        transition: transform 0.3s ease, box-shadow 0.3s ease;
-    }
-
-    .card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
-    }
-
-    .code-container {
-        background-color: #F8F8FF;
-        border-radius: 10px;
-        padding: 20px;
-        box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.1);
-        margin-top: 20px;
-    }
-
-    .glow-text {
-        color: #4682B4;
-    }
-
-    .sidebar-heading {
-        background-color: #4682B4;
-        padding: 10px;
-        border-radius: 8px;
-        text-align: center;
-        font-weight: 600;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-        margin-bottom: 15px;
-        color: white;
-    }
-
-    .status-success {
-        background-color: #90EE90;
-        color: #333333;
-        padding: 10px 15px;
-        border-radius: 8px;
-        font-weight: 600;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-        text-align: center;
-        margin: 15px 0;
-    }
-
-    .status-error {
-        background-color: #FFA07A;
-        color: #333333;
-        padding: 10px 15px;
-        border-radius: 8px;
-        font-weight: 600;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-        text-align: center;
-        margin: 15px 0;
-    }
-
-    .tab-container {
-        background-color: #F0F8FF;
-        border-radius: 12px;
-        padding: 20px;
-        margin-top: 20px;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-    }
-
-    .download-btn {
-        background-color: #4682B4;
-        color: white;
-        text-align: center;
-        padding: 12px 20px;
-        border-radius: 30px;
-        font-weight: 600;
-        display: block;
-        margin: 20px auto;
-        width: fit-content;
-        box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
-        transition: transform 0.3s ease, box-shadow 0.3s ease;
-    }
-
-    .download-btn:hover {
-        background-color: #5F9EA0;
-        transform: scale(1.05);
-        box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
-    }
-
-    .fade-in {
-        animation: fadeIn 1.5s ease-in-out;
-    }
-
-    @keyframes fadeIn {
-        from { opacity: 0; }
-        to { opacity: 1; }
-    }
-
-    /* Spinner styling */
-    .stSpinner > div > div {
-        border-color: #4682B4 #4682B4 transparent !important;
-    }
-    </style>
-    """, unsafe_allow_html=True)
-
-    # Custom Header
-    st.markdown('<div class="header fade-in"><span class="header-item">AI Agents powered by AGNO and BROWSER-USE</span></div>', unsafe_allow_html=True)
 
     # Main Title with custom styling
     st.markdown('<h1 class="main-title fade-in">AI BROWSER AUTOMATION</h1>', unsafe_allow_html=True)
@@ -647,7 +423,7 @@ def main():
                     st.markdown(f'<div class="status-error">Error generating {selected_framework} code: {str(e)}</div>', unsafe_allow_html=True)
 
     # Footer
-    st.markdown('<div class="footer fade-in">AI-Powered Test Automation</div>', unsafe_allow_html=True)
+    render_footer()
 
 if __name__ == "__main__":
     main()

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -1,0 +1,101 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
+.stApp {
+    font-family: 'Poppins', sans-serif;
+    background-color: #87CEEB; /* Sky blue background */
+    color: #333333;
+    padding: 2rem;
+}
+
+.header {
+    text-align: center;
+    padding: 1rem 2rem;
+    background-color: #4682B4; /* Steel blue for header */
+    border-radius: 10px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    margin-bottom: 2rem;
+    color: #FFFFFF;
+}
+
+.footer {
+    text-align: center;
+    margin-top: 2rem;
+    color: #333333;
+    font-size: 0.9rem;
+}
+
+.stButton > button {
+    background-color: #4682B4;
+    color: #FFFFFF;
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 0.6rem 1.2rem;
+    border-radius: 8px;
+    border: none;
+    transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.stButton > button:hover {
+    background-color: #5F9EA0;
+    transform: translateY(-2px);
+}
+
+.status-success {
+    background-color: #d4edda;
+    color: #155724;
+    padding: 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+}
+
+.status-error {
+    background-color: #f8d7da;
+    color: #721c24;
+    padding: 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+}
+
+.card, .code-container {
+    background-color: #FFFFFF;
+    padding: 1.5rem;
+    border-radius: 10px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    margin-bottom: 2rem;
+}
+
+.glow-text {
+    color: #4682B4;
+    text-shadow: 0 0 10px rgba(70, 130, 180, 0.5);
+}
+
+.tab-container {
+    background-color: #FFFFFF;
+    padding: 1rem;
+    border-radius: 10px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+.fade-in {
+    animation: fadeIn 1s ease-in;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.main-title {
+    color: #333333;
+    text-align: center;
+}
+
+.subtitle {
+    text-align: center;
+    color: #333333;
+}
+
+.sidebar-heading {
+    font-weight: 600;
+    color: #333333;
+}

--- a/src/frontend/ui.py
+++ b/src/frontend/ui.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import streamlit as st
+
+CSS_PATH = Path(__file__).with_name("styles.css")
+
+def set_page_config() -> None:
+    """Configure basic page settings."""
+    st.set_page_config(page_title="AI BROWSER AUTOMATION", layout="wide")
+
+def load_css() -> None:
+    """Load the CSS stylesheet for the Streamlit app."""
+    if CSS_PATH.exists():
+        css = CSS_PATH.read_text()
+        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+
+
+def render_header() -> None:
+    """Render the application header."""
+    st.markdown(
+        """
+        <div class="header">
+            <h1>AI Browser Automation</h1>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+def render_footer() -> None:
+    """Render the application footer."""
+    st.markdown(
+        '<div class="footer">AI-Powered Test Automation</div>',
+        unsafe_allow_html=True,
+    )


### PR DESCRIPTION
## Summary
- centralize Streamlit page configuration and styling in `src/frontend`
- load custom CSS and reusable header/footer helpers for a cleaner layout
- document the new frontend structure in the README

## Testing
- `python -m py_compile app.py src/frontend/ui.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb7f715fc832ab483f109d66c569c