### PR TITLE
Add mobile Appium agent for iOS and Android

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,3 +20,9 @@ streamlit run app.py
 ### Frontend
 
 The Streamlit user interface is organized in `src/frontend`. Custom styles live in `src/frontend/styles.css` and are loaded by `src/frontend/ui.py`.
+
+### Mobile Testing
+
+A dedicated mobile agent can transform manual iOS and Android test cases into
+Gherkin, execute them on real devices or emulators using Appium, and output
+PyTest automation code. See `src/Prompts/mobile_prompts.py` for usage examples.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ langchain-google-genai
 langchain-openai
 langchain-anthropic
 langchain-groq
+Appium-Python-Client

--- a/src/Agents/mobile_agents.py
+++ b/src/Agents/mobile_agents.py
@@ -1,0 +1,56 @@
+import os
+from textwrap import dedent
+from dotenv import load_dotenv
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+load_dotenv()
+
+# Agent for converting manual mobile test cases into Gherkin scenarios
+mobile_gherkin_agent = Agent(
+    model=OpenAIChat(id="gpt-4o", api_key=os.environ.get("OPENAI_API_KEY")),
+    markdown=True,
+    description=dedent("""
+        You are a QA expert focused on testing native and hybrid mobile
+        applications on both iOS and Android platforms. Your role is to
+        transform detailed manual test cases into concise, well structured
+        Gherkin scenarios and scenario outlines.
+    """),
+    instructions=dedent("""
+        Analyze the provided manual mobile test cases and convert them into a
+        single Gherkin feature file. Follow best practices for clarity and use of
+        Scenario versus Scenario Outline. Steps should describe user intent on
+        the mobile app rather than implementation details such as specific taps
+        or swipes.
+
+        Return only a markdown code block containing the Gherkin feature file.
+    """),
+    expected_output=dedent("""
+    ```gherkin
+    Feature: [Feature name]
+        # ...
+    ```
+    """),
+)
+
+# Agent for generating Appium based PyTest code
+mobile_code_gen_agent = Agent(
+    model=OpenAIChat(id="gpt-4o", api_key=os.environ.get("OPENAI_API_KEY")),
+    markdown=True,
+    description=dedent("""
+        You are an expert mobile automation engineer. Generate executable
+        PyTest code that uses Appium to automate iOS and Android applications.
+    """),
+    instructions=dedent("""
+        Using the provided Gherkin steps and any execution details, produce a
+        single self contained Python file that utilises Appium and PyTest. Include
+        necessary imports, setup of desired capabilities, and clear comments.
+
+        Return only a python code block.
+    """),
+    expected_output=dedent("""
+    ```python
+    # [PyTest code using Appium]
+    ```
+    """),
+)

--- a/src/Prompts/mobile_prompts.py
+++ b/src/Prompts/mobile_prompts.py
@@ -1,0 +1,102 @@
+import json
+import re
+from typing import Dict, Any
+
+from appium import webdriver
+
+from src.Agents.mobile_agents import mobile_gherkin_agent, mobile_code_gen_agent
+from src.Prompts.agno_prompts import extract_code_content
+from src.Utilities.utils import extract_selectors_from_history, analyze_actions
+
+
+def generate_mobile_gherkin_scenarios(manual_test_cases_markdown: str) -> str:
+    """Generate Gherkin scenarios for mobile apps."""
+    run_response = mobile_gherkin_agent.run(manual_test_cases_markdown)
+    return extract_code_content(run_response.content)
+
+
+def execute_mobile_steps(
+    gherkin_steps: str,
+    appium_server_url: str,
+    desired_capabilities: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Execute Gherkin steps on a mobile device using Appium.
+
+    Returns a history dictionary similar to the browser agent containing
+    action names and extracted content that can be used for code generation.
+    """
+    driver = webdriver.Remote(appium_server_url, desired_capabilities)
+    history: Dict[str, Any] = {"action_names": [], "extracted_content": [], "urls": []}
+    try:
+        for raw_line in gherkin_steps.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or line.endswith(":"):
+                continue
+            history["action_names"].append(line)
+            lower = line.lower()
+            if "tap" in lower:
+                match = re.search(r'"([^\"]+)"', line)
+                if match:
+                    element_id = match.group(1)
+                    try:
+                        el = driver.find_element("accessibility id", element_id)
+                        el.click()
+                        history["extracted_content"].append(f"Tapped element {element_id}")
+                    except Exception as e:  # pragma: no cover - best effort
+                        history["extracted_content"].append(
+                            f"Error tapping element {element_id}: {e}"
+                        )
+            elif "enter" in lower or "type" in lower:
+                # Expect pattern: enter "value" into "field"
+                matches = re.findall(r'"([^\"]+)"', line)
+                if len(matches) >= 2:
+                    value, element_id = matches[:2]
+                    try:
+                        el = driver.find_element("accessibility id", element_id)
+                        el.send_keys(value)
+                        history["extracted_content"].append(
+                            f"Entered {value} into {element_id}"
+                        )
+                    except Exception as e:  # pragma: no cover
+                        history["extracted_content"].append(
+                            f"Error entering text into {element_id}: {e}"
+                        )
+            elif "see" in lower or "should" in lower:
+                match = re.search(r'"([^\"]+)"', line)
+                if match:
+                    element_id = match.group(1)
+                    try:
+                        driver.find_element("accessibility id", element_id)
+                        history["extracted_content"].append(
+                            f"Verified element {element_id} is visible"
+                        )
+                    except Exception as e:  # pragma: no cover
+                        history["extracted_content"].append(
+                            f"Verification failed for {element_id}: {e}"
+                        )
+        return history
+    finally:
+        driver.quit()
+
+
+def generate_appium_pytest(gherkin_steps: str, history_data: Dict[str, Any]) -> str:
+    """Generate a PyTest file using Appium based on executed mobile steps."""
+    selectors = extract_selectors_from_history(history_data)
+    actions = analyze_actions(history_data)
+
+    code_file_prompt = f"""
+    Generate Appium PyTest code based on the following:
+
+    Gherkin Steps:
+    ```gherkin
+    {gherkin_steps}
+    ```
+
+    Agent Execution Details:
+    - Element Selectors: {json.dumps(selectors, indent=2)}
+    - Actions Performed: {json.dumps(actions, indent=2)}
+    - Extracted Content: {json.dumps(history_data.get('extracted_content', []), indent=2)}
+    """
+
+    code_response = mobile_code_gen_agent.run(code_file_prompt)
+    return extract_code_content(code_response.content)


### PR DESCRIPTION
## Summary
- add dedicated mobile agents for Gherkin generation and Appium PyTest code
- implement prompts for executing mobile steps via Appium and producing test scripts
- document mobile testing workflow and include Appium client dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aebad38280832a873d13d25d0c9f1b