### PR TITLE
feat: add mobile automation option via droidrun

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ langchain-openai
 langchain-anthropic
 langchain-groq
 Appium-Python-Client
+droidrun


### PR DESCRIPTION
## Summary
- allow choosing Browser or Mobile execution target in sidebar
- hook up mobile option to optional droidrun agent
- add droidrun to requirements

## Testing
- `python -m py_compile app.py`
- `python -m py_compile src/frontend/ui.py`
- `pip install droidrun` *(fails: Could not find a version that satisfies the requirement droidrun)*

------
https://chatgpt.com/codex/tasks/task_e_68aebd25b648832aa219bed25902e2be