### PR TITLE
Add mobile device info tab and FortiAgent branding

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,11 +79,11 @@ def main():
 
 
     # Main Title with custom styling
-    st.markdown('<h1 class="main-title fade-in">AI BROWSER AUTOMATION</h1>', unsafe_allow_html=True)
+    st.markdown('<h1 class="main-title fade-in">FortiAgent</h1>', unsafe_allow_html=True)
     st.markdown('<p class="subtitle fade-in">Prompts to Automated Tests : QA Browser Automation using AI Agents</p>', unsafe_allow_html=True)
     # Sidebar styling
     with st.sidebar:
-        st.markdown('<div class="sidebar-heading">AI BROWSER AUTOMATION</div>', unsafe_allow_html=True)
+        st.markdown('<div class="sidebar-heading">FortiAgent</div>', unsafe_allow_html=True)
 
         st.markdown('<div class="sidebar-heading">Avilable Frameworks</div>', unsafe_allow_html=True)
         selected_framework = st.selectbox(
@@ -333,12 +333,27 @@ def main():
                             "execution_date": st.session_state.get("execution_date", "Unknown")
                         }
 
+                        device_info = {}
+                        if selected_platform == "Mobile":
+                            try:
+                                driver = getattr(context, "driver", None)
+                                if driver is not None:
+                                    if hasattr(driver, "execute_script"):
+                                        info = driver.execute_script("mobile: deviceInfo")
+                                        if asyncio.iscoroutine(info):
+                                            info = await info
+                                        device_info = info
+                                    elif hasattr(driver, "capabilities"):
+                                        device_info = driver.capabilities
+                            except Exception as e:
+                                device_info = {"error": str(e)}
+
                         # Display test execution details
                         st.markdown('<div class="status-success fade-in">Test execution completed!</div>', unsafe_allow_html=True)
 
                         # Display key information in tabs
                         st.markdown('<div class="tab-container fade-in">', unsafe_allow_html=True)
-                        tab1, tab2, tab3, tab4 = st.tabs(["Results", "Actions", "Elements", "Details"])
+                        tab1, tab2, tab3, tab4, tab5 = st.tabs(["Results", "Actions", "Elements", "Details", "Device Info"])
                         with tab1:
                             for i, result in enumerate(all_results):
                                 st.markdown(f'<h4 class="glow-text">Scenario {i+1}</h4>', unsafe_allow_html=True)
@@ -379,6 +394,12 @@ def main():
                             st.markdown('<h4 class="glow-text">Extracted Content</h4>', unsafe_allow_html=True)
                             for content in all_extracted_content:
                                 st.write(content)
+                        with tab5:
+                            if device_info:
+                                st.markdown('<h4 class="glow-text">Device Information</h4>', unsafe_allow_html=True)
+                                st.json(device_info)
+                            else:
+                                st.info("No device information available.")
                         st.markdown('</div>', unsafe_allow_html=True)
 
                 except Exception as e:

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -86,13 +86,13 @@
 }
 
 .main-title {
-    color: #333333;
+    color: #4682B4;
     text-align: center;
 }
 
 .subtitle {
     text-align: center;
-    color: #333333;
+    color: #5F9EA0;
 }
 
 .sidebar-heading {

--- a/src/frontend/ui.py
+++ b/src/frontend/ui.py
@@ -5,7 +5,7 @@ CSS_PATH = Path(__file__).with_name("styles.css")
 
 def set_page_config() -> None:
     """Configure basic page settings."""
-    st.set_page_config(page_title="AI BROWSER AUTOMATION", layout="wide")
+    st.set_page_config(page_title="FortiAgent", layout="wide")
 
 def load_css() -> None:
     """Load the CSS stylesheet for the Streamlit app."""
@@ -19,7 +19,7 @@ def render_header() -> None:
     st.markdown(
         """
         <div class="header">
-            <h1>AI Browser Automation</h1>
+            <h1>FortiAgent</h1>
         </div>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- Rename UI to **FortiAgent** and update header/sidebar text
- Add device info tab for mobile runs using droidrun
- Adjust title and subtitle styling for better contrast

## Testing
- `python -m py_compile app.py src/frontend/ui.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec13626e4832abd7423fbcd5136e7